### PR TITLE
escape Unicode format control characters

### DIFF
--- a/currency/gen_aed.go
+++ b/currency/gen_aed.go
@@ -64,227 +64,227 @@ func (AED) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ar":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.إ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.إ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1817,10 +1817,10 @@ func (AED) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "AED",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1828,7 +1828,7 @@ func (AED) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2537,10 +2537,10 @@ func (AED) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "AED",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3332,7 +3332,7 @@ func (AED) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3340,7 +3340,7 @@ func (AED) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4020,7 +4020,7 @@ func (AED) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4028,7 +4028,7 @@ func (AED) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_afn.go
+++ b/currency/gen_afn.go
@@ -121,226 +121,226 @@ func (AFN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (AFN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (AFN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (AFN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "؋",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (AFN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (AFN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (AFN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (AFN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (AFN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (AFN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_all.go
+++ b/currency/gen_all.go
@@ -57,226 +57,226 @@ func (ALL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1729,10 +1729,10 @@ func (ALL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1740,7 +1740,7 @@ func (ALL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2337,10 +2337,10 @@ func (ALL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "ALL",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2900,7 +2900,7 @@ func (ALL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (ALL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3460,7 +3460,7 @@ func (ALL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (ALL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_amd.go
+++ b/currency/gen_amd.go
@@ -121,226 +121,226 @@ func (AMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (AMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (AMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (AMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "֏",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (AMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (AMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (AMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (AMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (AMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (AMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_ang.go
+++ b/currency/gen_ang.go
@@ -57,226 +57,226 @@ func (ANG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1729,10 +1729,10 @@ func (ANG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1740,7 +1740,7 @@ func (ANG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2337,10 +2337,10 @@ func (ANG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "ANG",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2900,7 +2900,7 @@ func (ANG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (ANG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3460,7 +3460,7 @@ func (ANG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (ANG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_aoa.go
+++ b/currency/gen_aoa.go
@@ -121,226 +121,226 @@ func (AOA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (AOA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (AOA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (AOA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "Kz",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (AOA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (AOA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (AOA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (AOA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (AOA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (AOA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_ars.go
+++ b/currency/gen_ars.go
@@ -121,226 +121,226 @@ func (ARS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "AR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (ARS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (ARS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (ARS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (ARS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (ARS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (ARS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (ARS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (ARS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (ARS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_aud.go
+++ b/currency/gen_aud.go
@@ -121,226 +121,226 @@ func (AUD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "AU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (AUD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "A$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (AUD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (AUD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "A$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (AUD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (AUD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (AUD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (AUD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (AUD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (AUD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_awg.go
+++ b/currency/gen_awg.go
@@ -57,226 +57,226 @@ func (AWG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1729,10 +1729,10 @@ func (AWG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1740,7 +1740,7 @@ func (AWG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2337,10 +2337,10 @@ func (AWG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "AWG",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2900,7 +2900,7 @@ func (AWG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (AWG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3460,7 +3460,7 @@ func (AWG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (AWG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_azn.go
+++ b/currency/gen_azn.go
@@ -121,226 +121,226 @@ func (AZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (AZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (AZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (AZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "₼",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (AZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (AZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (AZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (AZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (AZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (AZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_bam.go
+++ b/currency/gen_bam.go
@@ -121,226 +121,226 @@ func (BAM) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (BAM) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (BAM) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (BAM) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "KM",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (BAM) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (BAM) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (BAM) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (BAM) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (BAM) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (BAM) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_bbd.go
+++ b/currency/gen_bbd.go
@@ -121,226 +121,226 @@ func (BBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "BB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (BBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (BBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (BBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (BBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (BBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (BBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (BBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (BBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (BBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_bdt.go
+++ b/currency/gen_bdt.go
@@ -121,226 +121,226 @@ func (BDT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (BDT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (BDT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (BDT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "৳",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (BDT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (BDT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (BDT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (BDT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (BDT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (BDT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_bgn.go
+++ b/currency/gen_bgn.go
@@ -57,226 +57,226 @@ func (BGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1729,10 +1729,10 @@ func (BGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1740,7 +1740,7 @@ func (BGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2337,10 +2337,10 @@ func (BGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "BGN",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2900,7 +2900,7 @@ func (BGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (BGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3460,7 +3460,7 @@ func (BGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (BGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_bhd.go
+++ b/currency/gen_bhd.go
@@ -64,227 +64,227 @@ func (BHD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ar":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ب.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ب.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1817,10 +1817,10 @@ func (BHD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "BHD",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1828,7 +1828,7 @@ func (BHD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2537,10 +2537,10 @@ func (BHD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "BHD",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3332,7 +3332,7 @@ func (BHD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3340,7 +3340,7 @@ func (BHD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4020,7 +4020,7 @@ func (BHD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4028,7 +4028,7 @@ func (BHD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_bif.go
+++ b/currency/gen_bif.go
@@ -65,226 +65,226 @@ func (BIF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1817,10 +1817,10 @@ func (BIF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1828,7 +1828,7 @@ func (BIF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2545,10 +2545,10 @@ func (BIF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "BIF",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3340,7 +3340,7 @@ func (BIF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3348,7 +3348,7 @@ func (BIF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4028,7 +4028,7 @@ func (BIF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4036,7 +4036,7 @@ func (BIF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_bmd.go
+++ b/currency/gen_bmd.go
@@ -121,226 +121,226 @@ func (BMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "BM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (BMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (BMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (BMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (BMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (BMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (BMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (BMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (BMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (BMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_bnd.go
+++ b/currency/gen_bnd.go
@@ -121,226 +121,226 @@ func (BND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "BN$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (BND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (BND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (BND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (BND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (BND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (BND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (BND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (BND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (BND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_bob.go
+++ b/currency/gen_bob.go
@@ -121,226 +121,226 @@ func (BOB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (BOB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (BOB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (BOB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "Bs",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (BOB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (BOB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (BOB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (BOB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (BOB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (BOB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_bov.go
+++ b/currency/gen_bov.go
@@ -25,226 +25,226 @@ func (BOV) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "BOV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ast":
 		return CurrencyFormatInfo{

--- a/currency/gen_brl.go
+++ b/currency/gen_brl.go
@@ -121,226 +121,226 @@ func (BRL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (BRL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (BRL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (BRL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "R$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (BRL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (BRL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (BRL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (BRL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (BRL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (BRL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_bsd.go
+++ b/currency/gen_bsd.go
@@ -121,226 +121,226 @@ func (BSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "BS$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (BSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (BSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (BSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (BSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (BSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (BSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (BSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (BSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (BSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_btn.go
+++ b/currency/gen_btn.go
@@ -57,226 +57,226 @@ func (BTN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1777,10 +1777,10 @@ func (BTN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1788,7 +1788,7 @@ func (BTN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2385,10 +2385,10 @@ func (BTN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "BTN",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2948,7 +2948,7 @@ func (BTN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2956,7 +2956,7 @@ func (BTN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3508,7 +3508,7 @@ func (BTN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3516,7 +3516,7 @@ func (BTN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_bwp.go
+++ b/currency/gen_bwp.go
@@ -121,226 +121,226 @@ func (BWP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (BWP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (BWP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (BWP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "P",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (BWP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (BWP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (BWP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (BWP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (BWP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (BWP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_byn.go
+++ b/currency/gen_byn.go
@@ -57,226 +57,226 @@ func (BYN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "р.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1729,10 +1729,10 @@ func (BYN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "Br",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1740,7 +1740,7 @@ func (BYN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2345,10 +2345,10 @@ func (BYN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "р",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2916,7 +2916,7 @@ func (BYN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2924,7 +2924,7 @@ func (BYN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3476,7 +3476,7 @@ func (BYN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3484,7 +3484,7 @@ func (BYN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_bzd.go
+++ b/currency/gen_bzd.go
@@ -121,226 +121,226 @@ func (BZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "BZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (BZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (BZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (BZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (BZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (BZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (BZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (BZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (BZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (BZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_cad.go
+++ b/currency/gen_cad.go
@@ -121,226 +121,226 @@ func (CAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (CAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$CA",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (CAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (CAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "CA$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (CAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (CAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (CAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (CAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (CAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (CAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_cdf.go
+++ b/currency/gen_cdf.go
@@ -65,226 +65,226 @@ func (CDF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1817,10 +1817,10 @@ func (CDF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1828,7 +1828,7 @@ func (CDF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2537,10 +2537,10 @@ func (CDF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "CDF",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3332,7 +3332,7 @@ func (CDF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3340,7 +3340,7 @@ func (CDF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4020,7 +4020,7 @@ func (CDF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4028,7 +4028,7 @@ func (CDF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_chf.go
+++ b/currency/gen_chf.go
@@ -65,226 +65,226 @@ func (CHF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1817,10 +1817,10 @@ func (CHF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1828,7 +1828,7 @@ func (CHF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2545,10 +2545,10 @@ func (CHF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "CHF",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3340,7 +3340,7 @@ func (CHF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3348,7 +3348,7 @@ func (CHF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4028,7 +4028,7 @@ func (CHF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4036,7 +4036,7 @@ func (CHF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_clp.go
+++ b/currency/gen_clp.go
@@ -121,226 +121,226 @@ func (CLP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "CL$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (CLP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (CLP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (CLP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (CLP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (CLP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (CLP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (CLP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (CLP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (CLP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_cny.go
+++ b/currency/gen_cny.go
@@ -121,226 +121,226 @@ func (CNY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "CN¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (CNY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "¥CN",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (CNY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2984,11 +2984,11 @@ func (CNY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "he":
 		return CurrencyFormatInfo{
-			Symbol:           "‎CN¥‎",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Symbol:           "\u200eCN¥\u200e",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (CNY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (CNY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (CNY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (CNY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (CNY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (CNY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_cop.go
+++ b/currency/gen_cop.go
@@ -121,226 +121,226 @@ func (COP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "CO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (COP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (COP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (COP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (COP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (COP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (COP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (COP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (COP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (COP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_crc.go
+++ b/currency/gen_crc.go
@@ -121,226 +121,226 @@ func (CRC) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (CRC) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (CRC) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (CRC) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "₡",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (CRC) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (CRC) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (CRC) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (CRC) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (CRC) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (CRC) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_cup.go
+++ b/currency/gen_cup.go
@@ -121,226 +121,226 @@ func (CUP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "CU$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (CUP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (CUP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (CUP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (CUP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (CUP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (CUP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (CUP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (CUP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (CUP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_cve.go
+++ b/currency/gen_cve.go
@@ -65,226 +65,226 @@ func (CVE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1817,10 +1817,10 @@ func (CVE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1828,7 +1828,7 @@ func (CVE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2537,10 +2537,10 @@ func (CVE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "CVE",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2720,7 +2720,7 @@ func (CVE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "kea":
 		return CurrencyFormatInfo{
-			Symbol:           "​",
+			Symbol:           "\u200b",
 			Format:           "#,##0.00 ¤",
 			GroupSeparator:   " ",
 			DecimalSeparator: ",",
@@ -3316,7 +3316,7 @@ func (CVE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3324,7 +3324,7 @@ func (CVE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3352,7 +3352,7 @@ func (CVE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "pt-CV":
 		return CurrencyFormatInfo{
-			Symbol:           "​",
+			Symbol:           "\u200b",
 			Format:           "#,##0.00 ¤",
 			GroupSeparator:   " ",
 			DecimalSeparator: ",",
@@ -4004,7 +4004,7 @@ func (CVE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4012,7 +4012,7 @@ func (CVE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_czk.go
+++ b/currency/gen_czk.go
@@ -121,226 +121,226 @@ func (CZK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (CZK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (CZK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (CZK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "Kč",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (CZK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (CZK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (CZK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (CZK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (CZK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (CZK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_djf.go
+++ b/currency/gen_djf.go
@@ -73,226 +73,226 @@ func (DJF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "Fdj",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1825,10 +1825,10 @@ func (DJF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1836,7 +1836,7 @@ func (DJF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2545,10 +2545,10 @@ func (DJF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "DJF",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3324,7 +3324,7 @@ func (DJF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3332,7 +3332,7 @@ func (DJF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4012,7 +4012,7 @@ func (DJF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4020,7 +4020,7 @@ func (DJF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_dkk.go
+++ b/currency/gen_dkk.go
@@ -121,226 +121,226 @@ func (DKK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (DKK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (DKK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (DKK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (DKK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (DKK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (DKK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (DKK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (DKK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (DKK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_dop.go
+++ b/currency/gen_dop.go
@@ -121,226 +121,226 @@ func (DOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "DO$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (DOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (DOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (DOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (DOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (DOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (DOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (DOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (DOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (DOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_dzd.go
+++ b/currency/gen_dzd.go
@@ -64,227 +64,227 @@ func (DZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ar":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ج.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ج.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1825,10 +1825,10 @@ func (DZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "DZD",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1836,7 +1836,7 @@ func (DZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2553,10 +2553,10 @@ func (DZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "DZD",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3348,7 +3348,7 @@ func (DZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3356,7 +3356,7 @@ func (DZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4036,7 +4036,7 @@ func (DZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4044,7 +4044,7 @@ func (DZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_egp.go
+++ b/currency/gen_egp.go
@@ -120,227 +120,227 @@ func (EGP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ar":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
-			Symbol:           "ج.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ج.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (EGP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "E£",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (EGP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (EGP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "E£",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (EGP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (EGP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (EGP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (EGP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (EGP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (EGP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_ern.go
+++ b/currency/gen_ern.go
@@ -73,226 +73,226 @@ func (ERN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "Nfk",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1833,10 +1833,10 @@ func (ERN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1844,7 +1844,7 @@ func (ERN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2561,10 +2561,10 @@ func (ERN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "ERN",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3356,7 +3356,7 @@ func (ERN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3364,7 +3364,7 @@ func (ERN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4060,7 +4060,7 @@ func (ERN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4068,7 +4068,7 @@ func (ERN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_etb.go
+++ b/currency/gen_etb.go
@@ -89,226 +89,226 @@ func (ETB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1841,10 +1841,10 @@ func (ETB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1852,7 +1852,7 @@ func (ETB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2561,10 +2561,10 @@ func (ETB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "ETB",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3372,7 +3372,7 @@ func (ETB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3380,7 +3380,7 @@ func (ETB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4068,7 +4068,7 @@ func (ETB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4076,7 +4076,7 @@ func (ETB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_eur.go
+++ b/currency/gen_eur.go
@@ -121,226 +121,226 @@ func (EUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (EUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (EUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (EUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "€",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (EUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (EUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (EUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (EUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (EUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (EUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_fjd.go
+++ b/currency/gen_fjd.go
@@ -121,226 +121,226 @@ func (FJD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "FJ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (FJD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (FJD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (FJD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (FJD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (FJD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (FJD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (FJD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (FJD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (FJD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_fkp.go
+++ b/currency/gen_fkp.go
@@ -121,226 +121,226 @@ func (FKP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (FKP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (FKP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (FKP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (FKP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (FKP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (FKP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (FKP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (FKP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (FKP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_gbp.go
+++ b/currency/gen_gbp.go
@@ -121,226 +121,226 @@ func (GBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "GB£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "UK£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (GBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (GBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (GBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (GBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (GBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (GBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (GBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (GBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (GBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_gel.go
+++ b/currency/gen_gel.go
@@ -121,226 +121,226 @@ func (GEL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (GEL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (GEL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (GEL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "₾",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (GEL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (GEL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (GEL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (GEL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (GEL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (GEL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_ghs.go
+++ b/currency/gen_ghs.go
@@ -121,226 +121,226 @@ func (GHS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (GHS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (GHS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (GHS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "GH₵",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (GHS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (GHS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (GHS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (GHS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (GHS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (GHS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_gip.go
+++ b/currency/gen_gip.go
@@ -121,226 +121,226 @@ func (GIP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (GIP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (GIP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (GIP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (GIP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (GIP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (GIP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (GIP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (GIP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (GIP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_gmd.go
+++ b/currency/gen_gmd.go
@@ -65,226 +65,226 @@ func (GMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1817,10 +1817,10 @@ func (GMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1828,7 +1828,7 @@ func (GMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2537,10 +2537,10 @@ func (GMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "GMD",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3332,7 +3332,7 @@ func (GMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3340,7 +3340,7 @@ func (GMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4020,7 +4020,7 @@ func (GMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4028,7 +4028,7 @@ func (GMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_gnf.go
+++ b/currency/gen_gnf.go
@@ -121,226 +121,226 @@ func (GNF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (GNF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (GNF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (GNF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "FG",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (GNF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (GNF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (GNF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (GNF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (GNF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (GNF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_gtq.go
+++ b/currency/gen_gtq.go
@@ -121,226 +121,226 @@ func (GTQ) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (GTQ) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (GTQ) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (GTQ) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "Q",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (GTQ) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (GTQ) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (GTQ) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (GTQ) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (GTQ) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (GTQ) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_gyd.go
+++ b/currency/gen_gyd.go
@@ -121,226 +121,226 @@ func (GYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "GY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (GYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (GYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (GYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (GYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (GYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (GYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (GYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (GYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (GYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_hkd.go
+++ b/currency/gen_hkd.go
@@ -121,226 +121,226 @@ func (HKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (HKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$HK",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (HKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (HKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "HK$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (HKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (HKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (HKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (HKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (HKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (HKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_hnl.go
+++ b/currency/gen_hnl.go
@@ -121,226 +121,226 @@ func (HNL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (HNL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (HNL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (HNL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "L",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (HNL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (HNL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (HNL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (HNL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (HNL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (HNL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_htg.go
+++ b/currency/gen_htg.go
@@ -57,226 +57,226 @@ func (HTG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1729,10 +1729,10 @@ func (HTG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1740,7 +1740,7 @@ func (HTG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2337,10 +2337,10 @@ func (HTG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "HTG",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2900,7 +2900,7 @@ func (HTG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (HTG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3460,7 +3460,7 @@ func (HTG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (HTG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_huf.go
+++ b/currency/gen_huf.go
@@ -121,226 +121,226 @@ func (HUF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (HUF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (HUF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (HUF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "Ft",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (HUF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (HUF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (HUF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (HUF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (HUF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (HUF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_idr.go
+++ b/currency/gen_idr.go
@@ -121,226 +121,226 @@ func (IDR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (IDR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (IDR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (IDR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "Rp",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (IDR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (IDR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (IDR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (IDR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (IDR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (IDR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_ils.go
+++ b/currency/gen_ils.go
@@ -121,226 +121,226 @@ func (ILS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (ILS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (ILS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (ILS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "₪",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (ILS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (ILS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (ILS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (ILS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (ILS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (ILS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_inr.go
+++ b/currency/gen_inr.go
@@ -121,226 +121,226 @@ func (INR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (INR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (INR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (INR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "₹",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (INR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (INR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (INR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (INR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (INR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (INR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_iqd.go
+++ b/currency/gen_iqd.go
@@ -56,227 +56,227 @@ func (IQD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ar":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -488,7 +488,7 @@ func (IQD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ckb":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
+			Symbol:           "د.ع.\u200f",
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
@@ -496,7 +496,7 @@ func (IQD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ckb-IR":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
+			Symbol:           "د.ع.\u200f",
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
@@ -1753,10 +1753,10 @@ func (IQD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "IQD",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1764,7 +1764,7 @@ func (IQD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2361,10 +2361,10 @@ func (IQD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "IQD",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2664,7 +2664,7 @@ func (IQD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "lrc":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
+			Symbol:           "د.ع.\u200f",
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
@@ -2672,7 +2672,7 @@ func (IQD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "lrc-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ع.‏",
+			Symbol:           "د.ع.\u200f",
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
@@ -2940,7 +2940,7 @@ func (IQD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2948,7 +2948,7 @@ func (IQD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3500,7 +3500,7 @@ func (IQD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3508,7 +3508,7 @@ func (IQD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_irr.go
+++ b/currency/gen_irr.go
@@ -57,226 +57,226 @@ func (IRR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "ر.إ.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1777,10 +1777,10 @@ func (IRR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "ریال",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1788,7 +1788,7 @@ func (IRR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2393,10 +2393,10 @@ func (IRR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "IRR",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2956,7 +2956,7 @@ func (IRR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2964,7 +2964,7 @@ func (IRR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3516,7 +3516,7 @@ func (IRR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3524,7 +3524,7 @@ func (IRR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_isk.go
+++ b/currency/gen_isk.go
@@ -121,226 +121,226 @@ func (ISK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (ISK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (ISK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (ISK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (ISK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (ISK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (ISK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (ISK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (ISK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (ISK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_jmd.go
+++ b/currency/gen_jmd.go
@@ -121,226 +121,226 @@ func (JMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "JM$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (JMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (JMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (JMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (JMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (JMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (JMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (JMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (JMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (JMD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_jod.go
+++ b/currency/gen_jod.go
@@ -56,7 +56,7 @@ func (JOD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "apc":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
+			Symbol:           "د.أ.\u200f",
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
@@ -64,227 +64,227 @@ func (JOD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ar":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.أ.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.أ.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1745,10 +1745,10 @@ func (JOD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "JOD",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1756,7 +1756,7 @@ func (JOD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2353,10 +2353,10 @@ func (JOD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "JOD",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2916,7 +2916,7 @@ func (JOD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2924,7 +2924,7 @@ func (JOD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3476,7 +3476,7 @@ func (JOD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3484,7 +3484,7 @@ func (JOD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_jpy.go
+++ b/currency/gen_jpy.go
@@ -121,226 +121,226 @@ func (JPY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "JP¥",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (JPY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "¥",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (JPY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (JPY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "¥",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (JPY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (JPY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (JPY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (JPY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (JPY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (JPY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_kes.go
+++ b/currency/gen_kes.go
@@ -65,226 +65,226 @@ func (KES) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1825,10 +1825,10 @@ func (KES) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1836,7 +1836,7 @@ func (KES) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2545,10 +2545,10 @@ func (KES) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "KES",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3348,7 +3348,7 @@ func (KES) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3356,7 +3356,7 @@ func (KES) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4036,7 +4036,7 @@ func (KES) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4044,7 +4044,7 @@ func (KES) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_kgs.go
+++ b/currency/gen_kgs.go
@@ -121,226 +121,226 @@ func (KGS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (KGS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (KGS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (KGS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "⃀",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (KGS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (KGS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (KGS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (KGS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (KGS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (KGS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_khr.go
+++ b/currency/gen_khr.go
@@ -121,226 +121,226 @@ func (KHR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (KHR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (KHR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (KHR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "៛",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (KHR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (KHR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (KHR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (KHR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (KHR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (KHR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_kmf.go
+++ b/currency/gen_kmf.go
@@ -121,226 +121,226 @@ func (KMF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (KMF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (KMF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (KMF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "CF",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (KMF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (KMF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (KMF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (KMF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (KMF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (KMF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_kpw.go
+++ b/currency/gen_kpw.go
@@ -121,226 +121,226 @@ func (KPW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (KPW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (KPW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (KPW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (KPW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (KPW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (KPW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (KPW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (KPW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (KPW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_krw.go
+++ b/currency/gen_krw.go
@@ -121,226 +121,226 @@ func (KRW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (KRW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (KRW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (KRW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "₩",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (KRW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (KRW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (KRW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (KRW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (KRW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (KRW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_kwd.go
+++ b/currency/gen_kwd.go
@@ -56,227 +56,227 @@ func (KWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ar":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ك.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ك.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1737,10 +1737,10 @@ func (KWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "KWD",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1748,7 +1748,7 @@ func (KWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2345,10 +2345,10 @@ func (KWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "KWD",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (KWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2916,7 +2916,7 @@ func (KWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (KWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3476,7 +3476,7 @@ func (KWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_kyd.go
+++ b/currency/gen_kyd.go
@@ -121,226 +121,226 @@ func (KYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "KY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (KYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (KYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (KYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (KYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (KYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (KYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (KYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (KYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (KYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_kzt.go
+++ b/currency/gen_kzt.go
@@ -121,226 +121,226 @@ func (KZT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (KZT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (KZT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (KZT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "₸",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (KZT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (KZT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (KZT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (KZT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (KZT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (KZT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_lak.go
+++ b/currency/gen_lak.go
@@ -121,226 +121,226 @@ func (LAK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (LAK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (LAK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (LAK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "₭",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (LAK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (LAK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (LAK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (LAK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (LAK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (LAK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_lbp.go
+++ b/currency/gen_lbp.go
@@ -120,227 +120,227 @@ func (LBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ar":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (LBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "L£",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (LBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (LBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "L£",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (LBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (LBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (LBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (LBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (LBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (LBP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_lkr.go
+++ b/currency/gen_lkr.go
@@ -121,226 +121,226 @@ func (LKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (LKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (LKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (LKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (LKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (LKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (LKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (LKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (LKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (LKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_lrd.go
+++ b/currency/gen_lrd.go
@@ -121,226 +121,226 @@ func (LRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "$LR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (LRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (LRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (LRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (LRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (LRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (LRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (LRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (LRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (LRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_lsl.go
+++ b/currency/gen_lsl.go
@@ -65,226 +65,226 @@ func (LSL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1801,10 +1801,10 @@ func (LSL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1812,7 +1812,7 @@ func (LSL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2425,10 +2425,10 @@ func (LSL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "LSL",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3212,7 +3212,7 @@ func (LSL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3220,7 +3220,7 @@ func (LSL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3908,7 +3908,7 @@ func (LSL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3916,7 +3916,7 @@ func (LSL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_lyd.go
+++ b/currency/gen_lyd.go
@@ -64,227 +64,227 @@ func (LYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ar":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ل.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ل.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1825,10 +1825,10 @@ func (LYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "LYD",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1836,7 +1836,7 @@ func (LYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2545,10 +2545,10 @@ func (LYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "LYD",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3340,7 +3340,7 @@ func (LYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3348,7 +3348,7 @@ func (LYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4028,7 +4028,7 @@ func (LYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4036,7 +4036,7 @@ func (LYD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_mad.go
+++ b/currency/gen_mad.go
@@ -64,227 +64,227 @@ func (MAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ar":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.م.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.م.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1817,10 +1817,10 @@ func (MAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "MAD",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1828,7 +1828,7 @@ func (MAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2537,10 +2537,10 @@ func (MAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "MAD",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3332,7 +3332,7 @@ func (MAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3340,7 +3340,7 @@ func (MAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4020,7 +4020,7 @@ func (MAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4028,7 +4028,7 @@ func (MAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_mdl.go
+++ b/currency/gen_mdl.go
@@ -57,226 +57,226 @@ func (MDL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1729,10 +1729,10 @@ func (MDL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1740,7 +1740,7 @@ func (MDL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2337,10 +2337,10 @@ func (MDL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "MDL",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2900,7 +2900,7 @@ func (MDL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (MDL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3460,7 +3460,7 @@ func (MDL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (MDL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_mga.go
+++ b/currency/gen_mga.go
@@ -121,226 +121,226 @@ func (MGA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (MGA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (MGA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (MGA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "Ar",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (MGA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (MGA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (MGA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (MGA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (MGA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (MGA) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_mkd.go
+++ b/currency/gen_mkd.go
@@ -57,226 +57,226 @@ func (MKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1729,10 +1729,10 @@ func (MKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1740,7 +1740,7 @@ func (MKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2337,10 +2337,10 @@ func (MKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "MKD",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2900,7 +2900,7 @@ func (MKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (MKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3460,7 +3460,7 @@ func (MKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (MKD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_mmk.go
+++ b/currency/gen_mmk.go
@@ -121,226 +121,226 @@ func (MMK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (MMK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (MMK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (MMK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "K",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (MMK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (MMK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (MMK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (MMK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (MMK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (MMK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_mnt.go
+++ b/currency/gen_mnt.go
@@ -121,226 +121,226 @@ func (MNT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (MNT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (MNT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (MNT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "₮",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (MNT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (MNT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (MNT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (MNT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (MNT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (MNT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_mop.go
+++ b/currency/gen_mop.go
@@ -57,226 +57,226 @@ func (MOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1729,10 +1729,10 @@ func (MOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1740,7 +1740,7 @@ func (MOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2337,10 +2337,10 @@ func (MOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "MOP",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2900,7 +2900,7 @@ func (MOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (MOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3460,7 +3460,7 @@ func (MOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (MOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_mru.go
+++ b/currency/gen_mru.go
@@ -65,226 +65,226 @@ func (MRU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "أ.م.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1801,10 +1801,10 @@ func (MRU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "MRU",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1812,7 +1812,7 @@ func (MRU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2521,10 +2521,10 @@ func (MRU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "MRU",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3316,7 +3316,7 @@ func (MRU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3324,7 +3324,7 @@ func (MRU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4004,7 +4004,7 @@ func (MRU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4012,7 +4012,7 @@ func (MRU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_mur.go
+++ b/currency/gen_mur.go
@@ -121,226 +121,226 @@ func (MUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (MUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (MUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (MUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (MUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (MUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (MUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (MUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (MUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (MUR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_mvr.go
+++ b/currency/gen_mvr.go
@@ -57,226 +57,226 @@ func (MVR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1785,10 +1785,10 @@ func (MVR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1796,7 +1796,7 @@ func (MVR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2393,10 +2393,10 @@ func (MVR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "MVR",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2956,7 +2956,7 @@ func (MVR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2964,7 +2964,7 @@ func (MVR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3516,7 +3516,7 @@ func (MVR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3524,7 +3524,7 @@ func (MVR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_mwk.go
+++ b/currency/gen_mwk.go
@@ -65,226 +65,226 @@ func (MWK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1801,10 +1801,10 @@ func (MWK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1812,7 +1812,7 @@ func (MWK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2521,10 +2521,10 @@ func (MWK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "MWK",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3316,7 +3316,7 @@ func (MWK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3324,7 +3324,7 @@ func (MWK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4004,7 +4004,7 @@ func (MWK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4012,7 +4012,7 @@ func (MWK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_mxn.go
+++ b/currency/gen_mxn.go
@@ -121,226 +121,226 @@ func (MXN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (MXN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$MX",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (MXN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (MXN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "MX$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (MXN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (MXN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (MXN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (MXN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (MXN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (MXN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_mxv.go
+++ b/currency/gen_mxv.go
@@ -1849,10 +1849,10 @@ func (MXV) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "MXV",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi-Latn":
 		return CurrencyFormatInfo{

--- a/currency/gen_myr.go
+++ b/currency/gen_myr.go
@@ -121,226 +121,226 @@ func (MYR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (MYR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (MYR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (MYR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "RM",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (MYR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (MYR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (MYR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (MYR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (MYR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (MYR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_mzn.go
+++ b/currency/gen_mzn.go
@@ -57,226 +57,226 @@ func (MZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1713,10 +1713,10 @@ func (MZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1724,7 +1724,7 @@ func (MZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2321,10 +2321,10 @@ func (MZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "MZN",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2892,7 +2892,7 @@ func (MZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2900,7 +2900,7 @@ func (MZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3460,7 +3460,7 @@ func (MZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (MZN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_nad.go
+++ b/currency/gen_nad.go
@@ -121,226 +121,226 @@ func (NAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (NAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (NAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (NAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (NAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (NAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (NAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (NAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (NAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (NAD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_ngn.go
+++ b/currency/gen_ngn.go
@@ -121,226 +121,226 @@ func (NGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (NGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (NGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (NGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "₦",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (NGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (NGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (NGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (NGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (NGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (NGN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_nio.go
+++ b/currency/gen_nio.go
@@ -121,226 +121,226 @@ func (NIO) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (NIO) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (NIO) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (NIO) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "C$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (NIO) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (NIO) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (NIO) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (NIO) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (NIO) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (NIO) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_nok.go
+++ b/currency/gen_nok.go
@@ -121,226 +121,226 @@ func (NOK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (NOK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (NOK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (NOK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (NOK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (NOK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (NOK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (NOK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (NOK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (NOK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_npr.go
+++ b/currency/gen_npr.go
@@ -121,226 +121,226 @@ func (NPR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (NPR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (NPR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (NPR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (NPR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (NPR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (NPR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (NPR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (NPR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (NPR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_nzd.go
+++ b/currency/gen_nzd.go
@@ -121,226 +121,226 @@ func (NZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (NZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$NZ",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (NZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (NZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "NZ$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (NZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (NZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (NZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (NZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (NZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (NZD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_omr.go
+++ b/currency/gen_omr.go
@@ -56,227 +56,227 @@ func (OMR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ar":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ع.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ع.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1737,10 +1737,10 @@ func (OMR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "OMR",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1748,7 +1748,7 @@ func (OMR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2345,10 +2345,10 @@ func (OMR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "OMR",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (OMR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2916,7 +2916,7 @@ func (OMR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (OMR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3476,7 +3476,7 @@ func (OMR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_pab.go
+++ b/currency/gen_pab.go
@@ -57,226 +57,226 @@ func (PAB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1737,10 +1737,10 @@ func (PAB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1748,7 +1748,7 @@ func (PAB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2345,10 +2345,10 @@ func (PAB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "PAB",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (PAB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2916,7 +2916,7 @@ func (PAB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (PAB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3476,7 +3476,7 @@ func (PAB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_pen.go
+++ b/currency/gen_pen.go
@@ -57,226 +57,226 @@ func (PEN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1737,10 +1737,10 @@ func (PEN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1748,7 +1748,7 @@ func (PEN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2345,10 +2345,10 @@ func (PEN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "PEN",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (PEN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2916,7 +2916,7 @@ func (PEN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (PEN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3476,7 +3476,7 @@ func (PEN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_pgk.go
+++ b/currency/gen_pgk.go
@@ -57,226 +57,226 @@ func (PGK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1729,10 +1729,10 @@ func (PGK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1740,7 +1740,7 @@ func (PGK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2337,10 +2337,10 @@ func (PGK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "PGK",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2892,7 +2892,7 @@ func (PGK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2900,7 +2900,7 @@ func (PGK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3460,7 +3460,7 @@ func (PGK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (PGK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_php.go
+++ b/currency/gen_php.go
@@ -121,226 +121,226 @@ func (PHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (PHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (PHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (PHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "PHP",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (PHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (PHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (PHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (PHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (PHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (PHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_pkr.go
+++ b/currency/gen_pkr.go
@@ -121,226 +121,226 @@ func (PKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (PKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (PKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (PKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "Rs",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (PKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (PKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (PKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (PKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (PKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (PKR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_pln.go
+++ b/currency/gen_pln.go
@@ -121,226 +121,226 @@ func (PLN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (PLN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (PLN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (PLN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "zł",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (PLN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (PLN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (PLN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (PLN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (PLN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (PLN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_pyg.go
+++ b/currency/gen_pyg.go
@@ -121,226 +121,226 @@ func (PYG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (PYG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (PYG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (PYG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "₲",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (PYG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (PYG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (PYG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (PYG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (PYG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (PYG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_qar.go
+++ b/currency/gen_qar.go
@@ -56,227 +56,227 @@ func (QAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ar":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ق.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ق.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1737,10 +1737,10 @@ func (QAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "QAR",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1748,7 +1748,7 @@ func (QAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2345,10 +2345,10 @@ func (QAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "QAR",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (QAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2916,7 +2916,7 @@ func (QAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (QAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3476,7 +3476,7 @@ func (QAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_ron.go
+++ b/currency/gen_ron.go
@@ -121,226 +121,226 @@ func (RON) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (RON) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (RON) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (RON) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "lei",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (RON) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (RON) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (RON) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (RON) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (RON) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (RON) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_rsd.go
+++ b/currency/gen_rsd.go
@@ -57,226 +57,226 @@ func (RSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1729,10 +1729,10 @@ func (RSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1740,7 +1740,7 @@ func (RSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2345,10 +2345,10 @@ func (RSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "RSD",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (RSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2916,7 +2916,7 @@ func (RSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (RSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3476,7 +3476,7 @@ func (RSD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_rub.go
+++ b/currency/gen_rub.go
@@ -121,226 +121,226 @@ func (RUB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (RUB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (RUB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (RUB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "₽",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (RUB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (RUB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (RUB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (RUB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (RUB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (RUB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_rwf.go
+++ b/currency/gen_rwf.go
@@ -121,226 +121,226 @@ func (RWF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (RWF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (RWF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (RWF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "RF",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (RWF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (RWF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (RWF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (RWF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (RWF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (RWF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_sar.go
+++ b/currency/gen_sar.go
@@ -64,227 +64,227 @@ func (SAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ar":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1817,10 +1817,10 @@ func (SAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "SAR",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1828,7 +1828,7 @@ func (SAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2545,10 +2545,10 @@ func (SAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "SAR",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3340,7 +3340,7 @@ func (SAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3348,7 +3348,7 @@ func (SAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4028,7 +4028,7 @@ func (SAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4036,7 +4036,7 @@ func (SAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_sbd.go
+++ b/currency/gen_sbd.go
@@ -121,226 +121,226 @@ func (SBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "SB$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (SBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (SBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (SBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (SBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (SBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (SBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (SBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (SBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (SBD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_scr.go
+++ b/currency/gen_scr.go
@@ -65,226 +65,226 @@ func (SCR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1817,10 +1817,10 @@ func (SCR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1828,7 +1828,7 @@ func (SCR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2537,10 +2537,10 @@ func (SCR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "SCR",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3316,7 +3316,7 @@ func (SCR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3324,7 +3324,7 @@ func (SCR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4004,7 +4004,7 @@ func (SCR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4012,7 +4012,7 @@ func (SCR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_sdg.go
+++ b/currency/gen_sdg.go
@@ -65,226 +65,226 @@ func (SDG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "SDG",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "ج.س.",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1809,10 +1809,10 @@ func (SDG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "SDG",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1820,7 +1820,7 @@ func (SDG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2529,10 +2529,10 @@ func (SDG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "SDG",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3324,7 +3324,7 @@ func (SDG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3332,7 +3332,7 @@ func (SDG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4012,7 +4012,7 @@ func (SDG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4020,7 +4020,7 @@ func (SDG) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_sek.go
+++ b/currency/gen_sek.go
@@ -121,226 +121,226 @@ func (SEK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (SEK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (SEK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (SEK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "kr",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (SEK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (SEK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (SEK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (SEK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (SEK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (SEK) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_sgd.go
+++ b/currency/gen_sgd.go
@@ -121,226 +121,226 @@ func (SGD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (SGD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (SGD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (SGD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (SGD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (SGD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (SGD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (SGD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (SGD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (SGD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_shp.go
+++ b/currency/gen_shp.go
@@ -121,226 +121,226 @@ func (SHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (SHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (SHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (SHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (SHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (SHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (SHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (SHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (SHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (SHP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_sle.go
+++ b/currency/gen_sle.go
@@ -65,226 +65,226 @@ func (SLE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1809,10 +1809,10 @@ func (SLE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1820,7 +1820,7 @@ func (SLE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2529,10 +2529,10 @@ func (SLE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "SLE",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3308,7 +3308,7 @@ func (SLE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3316,7 +3316,7 @@ func (SLE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3996,7 +3996,7 @@ func (SLE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4004,7 +4004,7 @@ func (SLE) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_sos.go
+++ b/currency/gen_sos.go
@@ -65,226 +65,226 @@ func (SOS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "S",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1809,10 +1809,10 @@ func (SOS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1820,7 +1820,7 @@ func (SOS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2529,10 +2529,10 @@ func (SOS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "SOS",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3324,7 +3324,7 @@ func (SOS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3332,7 +3332,7 @@ func (SOS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4012,7 +4012,7 @@ func (SOS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4020,7 +4020,7 @@ func (SOS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_srd.go
+++ b/currency/gen_srd.go
@@ -121,226 +121,226 @@ func (SRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "SR$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (SRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (SRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (SRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (SRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (SRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (SRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (SRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (SRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (SRD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_ssp.go
+++ b/currency/gen_ssp.go
@@ -121,226 +121,226 @@ func (SSP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (SSP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (SSP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (SSP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (SSP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (SSP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (SSP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (SSP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (SSP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (SSP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_stn.go
+++ b/currency/gen_stn.go
@@ -121,226 +121,226 @@ func (STN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (STN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (STN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (STN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "Db",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (STN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (STN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (STN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (STN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (STN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (STN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_svc.go
+++ b/currency/gen_svc.go
@@ -25,226 +25,226 @@ func (SVC) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ast":
 		return CurrencyFormatInfo{
@@ -2161,10 +2161,10 @@ func (SVC) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "SVC",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi-Latn":
 		return CurrencyFormatInfo{

--- a/currency/gen_syp.go
+++ b/currency/gen_syp.go
@@ -120,227 +120,227 @@ func (SYP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ar":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
-			Symbol:           "ل.س.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ل.س.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (SYP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (SYP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (SYP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "£",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (SYP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (SYP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (SYP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (SYP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (SYP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (SYP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_szl.go
+++ b/currency/gen_szl.go
@@ -65,226 +65,226 @@ func (SZL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1801,10 +1801,10 @@ func (SZL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1812,7 +1812,7 @@ func (SZL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2521,10 +2521,10 @@ func (SZL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "SZL",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3316,7 +3316,7 @@ func (SZL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3324,7 +3324,7 @@ func (SZL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4020,7 +4020,7 @@ func (SZL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4028,7 +4028,7 @@ func (SZL) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_thb.go
+++ b/currency/gen_thb.go
@@ -121,226 +121,226 @@ func (THB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (THB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (THB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (THB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "฿",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (THB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (THB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (THB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (THB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (THB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (THB) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_tjs.go
+++ b/currency/gen_tjs.go
@@ -57,226 +57,226 @@ func (TJS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1737,10 +1737,10 @@ func (TJS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1748,7 +1748,7 @@ func (TJS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2345,10 +2345,10 @@ func (TJS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "TJS",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (TJS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2916,7 +2916,7 @@ func (TJS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (TJS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3476,7 +3476,7 @@ func (TJS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_tmt.go
+++ b/currency/gen_tmt.go
@@ -57,226 +57,226 @@ func (TMT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1729,10 +1729,10 @@ func (TMT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1740,7 +1740,7 @@ func (TMT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2313,10 +2313,10 @@ func (TMT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "TMT",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2860,7 +2860,7 @@ func (TMT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2868,7 +2868,7 @@ func (TMT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3420,7 +3420,7 @@ func (TMT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3428,7 +3428,7 @@ func (TMT) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_tnd.go
+++ b/currency/gen_tnd.go
@@ -64,227 +64,227 @@ func (TND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ar":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
-			Symbol:           "د.ت.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "د.ت.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1809,10 +1809,10 @@ func (TND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "TND",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1820,7 +1820,7 @@ func (TND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2529,10 +2529,10 @@ func (TND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "TND",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3324,7 +3324,7 @@ func (TND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3332,7 +3332,7 @@ func (TND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4012,7 +4012,7 @@ func (TND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4020,7 +4020,7 @@ func (TND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_top.go
+++ b/currency/gen_top.go
@@ -121,226 +121,226 @@ func (TOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (TOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (TOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (TOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "T$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (TOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (TOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (TOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (TOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (TOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (TOP) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_try.go
+++ b/currency/gen_try.go
@@ -121,226 +121,226 @@ func (TRY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (TRY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (TRY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (TRY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "₺",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (TRY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (TRY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (TRY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (TRY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (TRY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (TRY) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_ttd.go
+++ b/currency/gen_ttd.go
@@ -121,226 +121,226 @@ func (TTD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "TT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (TTD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (TTD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (TTD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (TTD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (TTD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (TTD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (TTD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (TTD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (TTD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_twd.go
+++ b/currency/gen_twd.go
@@ -121,226 +121,226 @@ func (TWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (TWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (TWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (TWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "NT$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (TWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (TWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (TWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (TWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (TWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (TWD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_tzs.go
+++ b/currency/gen_tzs.go
@@ -65,226 +65,226 @@ func (TZS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1817,10 +1817,10 @@ func (TZS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1828,7 +1828,7 @@ func (TZS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2537,10 +2537,10 @@ func (TZS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "TZS",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3332,7 +3332,7 @@ func (TZS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3340,7 +3340,7 @@ func (TZS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4020,7 +4020,7 @@ func (TZS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4028,7 +4028,7 @@ func (TZS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_uah.go
+++ b/currency/gen_uah.go
@@ -121,226 +121,226 @@ func (UAH) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (UAH) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (UAH) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (UAH) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "₴",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (UAH) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (UAH) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (UAH) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (UAH) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (UAH) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (UAH) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_ugx.go
+++ b/currency/gen_ugx.go
@@ -65,226 +65,226 @@ func (UGX) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1817,10 +1817,10 @@ func (UGX) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1828,7 +1828,7 @@ func (UGX) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2537,10 +2537,10 @@ func (UGX) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "UGX",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -3332,7 +3332,7 @@ func (UGX) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -3340,7 +3340,7 @@ func (UGX) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -4020,7 +4020,7 @@ func (UGX) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -4028,7 +4028,7 @@ func (UGX) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_usd.go
+++ b/currency/gen_usd.go
@@ -121,226 +121,226 @@ func (USD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "US$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (USD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (USD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (USD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (USD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (USD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (USD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (USD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (USD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (USD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_usn.go
+++ b/currency/gen_usn.go
@@ -25,226 +25,226 @@ func (USN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ast":
 		return CurrencyFormatInfo{
@@ -1601,10 +1601,10 @@ func (USN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1612,7 +1612,7 @@ func (USN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2153,10 +2153,10 @@ func (USN) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "USN",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{

--- a/currency/gen_uyu.go
+++ b/currency/gen_uyu.go
@@ -121,226 +121,226 @@ func (UYU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "UY$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (UYU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (UYU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (UYU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (UYU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (UYU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (UYU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (UYU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (UYU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (UYU) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_uzs.go
+++ b/currency/gen_uzs.go
@@ -57,226 +57,226 @@ func (UZS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1737,10 +1737,10 @@ func (UZS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1748,7 +1748,7 @@ func (UZS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2345,10 +2345,10 @@ func (UZS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "UZS",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (UZS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2916,7 +2916,7 @@ func (UZS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (UZS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3476,7 +3476,7 @@ func (UZS) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_ves.go
+++ b/currency/gen_ves.go
@@ -57,226 +57,226 @@ func (VES) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1721,10 +1721,10 @@ func (VES) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1732,7 +1732,7 @@ func (VES) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2329,10 +2329,10 @@ func (VES) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "VES",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2892,7 +2892,7 @@ func (VES) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2900,7 +2900,7 @@ func (VES) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3452,7 +3452,7 @@ func (VES) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3460,7 +3460,7 @@ func (VES) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_vnd.go
+++ b/currency/gen_vnd.go
@@ -121,226 +121,226 @@ func (VND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (VND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (VND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (VND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "₫",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (VND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (VND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (VND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (VND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (VND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (VND) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_vuv.go
+++ b/currency/gen_vuv.go
@@ -57,226 +57,226 @@ func (VUV) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1729,10 +1729,10 @@ func (VUV) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1740,7 +1740,7 @@ func (VUV) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2337,10 +2337,10 @@ func (VUV) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "VUV",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2892,7 +2892,7 @@ func (VUV) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2900,7 +2900,7 @@ func (VUV) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3460,7 +3460,7 @@ func (VUV) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (VUV) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_wst.go
+++ b/currency/gen_wst.go
@@ -57,226 +57,226 @@ func (WST) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1729,10 +1729,10 @@ func (WST) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1740,7 +1740,7 @@ func (WST) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2337,10 +2337,10 @@ func (WST) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "WST",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2892,7 +2892,7 @@ func (WST) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2900,7 +2900,7 @@ func (WST) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3460,7 +3460,7 @@ func (WST) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (WST) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_xaf.go
+++ b/currency/gen_xaf.go
@@ -121,226 +121,226 @@ func (XAF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (XAF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (XAF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (XAF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "FCFA",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (XAF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (XAF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (XAF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (XAF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (XAF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (XAF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_xcd.go
+++ b/currency/gen_xcd.go
@@ -121,226 +121,226 @@ func (XCD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (XCD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "$EC",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (XCD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (XCD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "EC$",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (XCD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (XCD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (XCD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (XCD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (XCD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (XCD) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_xdr.go
+++ b/currency/gen_xdr.go
@@ -25,226 +25,226 @@ func (XDR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ast":
 		return CurrencyFormatInfo{
@@ -2001,10 +2001,10 @@ func (XDR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "XDR",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi-Latn":
 		return CurrencyFormatInfo{

--- a/currency/gen_xof.go
+++ b/currency/gen_xof.go
@@ -121,226 +121,226 @@ func (XOF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (XOF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "فرانک CFA",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (XOF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (XOF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "F CFA",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (XOF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (XOF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (XOF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (XOF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (XOF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (XOF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_xpf.go
+++ b/currency/gen_xpf.go
@@ -121,226 +121,226 @@ func (XPF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (XPF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (XPF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (XPF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "CFPF",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (XPF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (XPF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (XPF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (XPF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (XPF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (XPF) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_yer.go
+++ b/currency/gen_yer.go
@@ -56,227 +56,227 @@ func (YER) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 		}
 	case "ar":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
-			Symbol:           "ر.ي.‏",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Symbol:           "ر.ي.\u200f",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "as":
 		return CurrencyFormatInfo{
@@ -1729,10 +1729,10 @@ func (YER) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "YER",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -1740,7 +1740,7 @@ func (YER) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff-Adlm":
 		return CurrencyFormatInfo{
@@ -2337,10 +2337,10 @@ func (YER) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "YER",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -2900,7 +2900,7 @@ func (YER) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -2908,7 +2908,7 @@ func (YER) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -3460,7 +3460,7 @@ func (YER) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -3468,7 +3468,7 @@ func (YER) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{

--- a/currency/gen_zar.go
+++ b/currency/gen_zar.go
@@ -121,226 +121,226 @@ func (ZAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (ZAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (ZAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (ZAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "R",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (ZAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (ZAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (ZAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (ZAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (ZAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (ZAR) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/currency/gen_zmw.go
+++ b/currency/gen_zmw.go
@@ -121,226 +121,226 @@ func (ZMW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "ar":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-AE":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-BH":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DJ":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-DZ":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EG":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-EH":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-ER":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IL":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-IQ":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-JO":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KM":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-KW":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LB":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-LY":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MA":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-MR":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-OM":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-PS":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-QA":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SA":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SD":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SO":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SS":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-SY":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TD":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-TN":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ar-YE":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ¤;‏-#,##0.00 ¤",
+			Format:           "\u200f#,##0.00 ¤;\u200f-#,##0.00 ¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "arn":
 		return CurrencyFormatInfo{
@@ -2185,10 +2185,10 @@ func (ZMW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "fa":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‎¤ #,##0.00",
+			Format:           "\u200e¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "fa-AF":
 		return CurrencyFormatInfo{
@@ -2196,7 +2196,7 @@ func (ZMW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ff":
 		return CurrencyFormatInfo{
@@ -2985,10 +2985,10 @@ func (ZMW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 	case "he":
 		return CurrencyFormatInfo{
 			Symbol:           "ZK",
-			Format:           "‏#,##0.00 ‏¤;‏-#,##0.00 ‏¤",
+			Format:           "\u200f#,##0.00 \u200f¤;\u200f-#,##0.00 \u200f¤",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "hi":
 		return CurrencyFormatInfo{
@@ -4292,7 +4292,7 @@ func (ZMW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "pa-Guru":
 		return CurrencyFormatInfo{
@@ -4356,7 +4356,7 @@ func (ZMW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "ps-PK":
 		return CurrencyFormatInfo{
@@ -4364,7 +4364,7 @@ func (ZMW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "pt":
 		return CurrencyFormatInfo{
@@ -5444,7 +5444,7 @@ func (ZMW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "ur-IN":
 		return CurrencyFormatInfo{
@@ -5452,7 +5452,7 @@ func (ZMW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤#,##0.00",
 			GroupSeparator:   ",",
 			DecimalSeparator: ".",
-			MinusSign:        "‎-",
+			MinusSign:        "\u200e-",
 		}
 	case "uz":
 		return CurrencyFormatInfo{
@@ -5468,7 +5468,7 @@ func (ZMW) FormatInfo(locale locale.Locale) CurrencyFormatInfo {
 			Format:           "¤ #,##0.00",
 			GroupSeparator:   ".",
 			DecimalSeparator: ",",
-			MinusSign:        "‎−",
+			MinusSign:        "\u200e−",
 		}
 	case "uz-Cyrl":
 		return CurrencyFormatInfo{

--- a/generator.go
+++ b/generator.go
@@ -425,10 +425,10 @@ func (g *Generator) processLocales() error {
 		localeData := numbersFile.Main[locale].Numbers
 
 		g.Locales[locale] = &CurrencyFormatInfo{
-			Format:           localeData.CurrencyFormats.Standard,
-			GroupSeparator:   localeData.Symbols.Group,
-			DecimalSeparator: localeData.Symbols.Decimal,
-			MinusSign:        localeData.Symbols.Minus,
+			Format:           cleanFormatCharacters(localeData.CurrencyFormats.Standard),
+			GroupSeparator:   cleanFormatCharacters(localeData.Symbols.Group),
+			DecimalSeparator: cleanFormatCharacters(localeData.Symbols.Decimal),
+			MinusSign:        cleanFormatCharacters(localeData.Symbols.Minus),
 		}
 
 		currenciesData, err := os.ReadFile(filepath.Join(localesPath, locale, "currencies.json"))
@@ -462,6 +462,8 @@ func (g *Generator) processLocales() error {
 						symbol = code
 					}
 				}
+
+				symbol = cleanFormatCharacters(symbol)
 
 				currency.LocalizedInfo[locale] = &CurrencyFormatInfo{
 					Symbol:           symbol,
@@ -564,4 +566,17 @@ func (g *Generator) generateCurrencies() error {
 	}
 
 	return nil
+}
+
+func cleanFormatCharacters(s string) string {
+	var result strings.Builder
+	for _, r := range s {
+		switch r {
+		case '\u200b', '\u200e', '\u200f', '\u202a', '\u202b', '\u202c', '\u202d', '\u202e':
+			result.WriteString(fmt.Sprintf("\\u%04x", r))
+		default:
+			result.WriteRune(r)
+		}
+	}
+	return result.String()
 }


### PR DESCRIPTION
Converts bidirectional format control characters (LRM, RLM, LRE, RLE, PDF, LRO, RLO) to their escaped Unicode representation for better visibility and handling